### PR TITLE
Add support for GITHUB_TOKEN env var for auth

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,7 +12,7 @@ from github and assembles them into a unified view.
 
 * Helps visualize patterns across the years.
 * See the effects of major life events (eg marriage, baby, depression).
-* Uses ~/.config/gh/hosts.yml for authentication (generate via `gh auth login`).
+* Uses GITHUB_TOKEN env var or ~/.config/gh/hosts.yml for authentication (generate via `gh auth login`).
 * Caches all previous years (current year is always generated).
 * Defaults to 10 years, but takes an optional year.
 

--- a/lib/github_contribs.rb
+++ b/lib/github_contribs.rb
@@ -8,6 +8,9 @@ class GithubContribs
   VERSION = "1.0.0"
 
   def oauth_token
+    return @token if defined? @token
+
+    @token = ENV["GITHUB_TOKEN"]
     @token ||= begin
                  data = YAML.load_file File.expand_path "~/.config/gh/hosts.yml"
                  data && data.dig("github.com", "oauth_token")


### PR DESCRIPTION
`gh auth login` will not create a ~/.config/gh/hosts.yml file if it detects a GITHUB_TOKEN env var (though one can force gh to do that), and a missing config file will fail. Instead of forcing it, this commit allows the GITHUB_TOKEN env var to be accepted.